### PR TITLE
Add a development mode for contributions in "flogo ensure"

### DIFF
--- a/app/api.go
+++ b/app/api.go
@@ -3,6 +3,7 @@ package app
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"github.com/TIBCOSoftware/flogo-lib/logger"
 	"html/template"
@@ -624,6 +625,25 @@ func Ensure(depManager *dep.DepManager, developmentMode bool, args ...string) (r
 			if err != nil {
 				logger.Errorf("unable to create symbolic link from %s to %s", linkFrom, linkTo)
 				continue
+			}
+
+			if props.Constraint.String() != "" { // checkout right branch
+				exists := fgutil.ExecutableExists("git")
+				if !exists {
+					return errors.New("git not installed")
+				}
+
+				cmd := exec.Command("git", "checkout", props.Constraint.String())
+				cmd.Dir = linkTo
+
+				cmd.Stdout = nil
+				cmd.Stderr = nil
+
+				err = cmd.Run()
+				if err != nil {
+					result = err
+					break
+				}
 			}
 		}
 	}

--- a/app/ensure.go
+++ b/app/ensure.go
@@ -11,12 +11,13 @@ import (
 
 var optEnsure = &cli.OptionInfo{
 	Name:      "ensure",
-	UsageLine: "ensure [-add][-update][-no-vendor | -vendor-only][-v]",
+	UsageLine: "ensure [-add][-dev][-update][-no-vendor | -vendor-only][-v]",
 	Short:     "Ensure gets a project into a complete, reproducible, and likely compilable state",
 	Long: `Ensure gets a project into a complete, reproducible, and likely compilable state:
 
   Options:
     -add              add new dependencies, or populate Gopkg.toml with constraints for existing dependencies (default: false)
+    -dev              set up project for development of contributions
     -no-vendor        update Gopkg.lock (if needed), but do not update vendor/ (default: false)
     -update           update the named dependencies (or all, if none are named) in Gopkg.lock to the latest allowed by Gopkg.toml (default: false)
     -v                enable verbose logging (default: false)
@@ -32,6 +33,7 @@ func init() {
 type cmdEnsure struct {
 	option     *cli.OptionInfo
 	add        string
+	dev        bool
 	update     bool
 	noVendor   bool
 	verbose    bool
@@ -46,6 +48,7 @@ func (c *cmdEnsure) OptionInfo() *cli.OptionInfo {
 // AddFlags implementation of cli.Command.AddFlags
 func (c *cmdEnsure) AddFlags(fs *flag.FlagSet) {
 	fs.StringVar(&(c.add), "add", "", "add")
+	fs.BoolVar(&(c.dev), "dev", false, "dev")
 	fs.BoolVar(&(c.update), "update", false, "update")
 	fs.BoolVar(&(c.noVendor), "no-vendor", false, "no-vendor")
 	fs.BoolVar(&(c.verbose), "verbose", false, "verbose")
@@ -86,5 +89,5 @@ func (c *cmdEnsure) Exec(args []string) error {
 
 	depManager := dep.New(SetupExistingProjectEnv(rootDir))
 
-	return Ensure(depManager, ensureArgs...)
+	return Ensure(depManager, c.dev, ensureArgs...)
 }

--- a/app/install.go
+++ b/app/install.go
@@ -25,9 +25,12 @@ func init() {
 }
 
 type cmdInstall struct {
-	option  *cli.OptionInfo
-	version string
-	palette bool
+	option         *cli.OptionInfo
+	version        string
+	source         string
+	override       bool
+	palette        bool
+	updateIfExists bool
 }
 
 // HasOptionInfo implementation of cli.HasOptionInfo.OptionInfo
@@ -38,8 +41,10 @@ func (c *cmdInstall) OptionInfo() *cli.OptionInfo {
 // AddFlags implementation of cli.Command.AddFlags
 func (c *cmdInstall) AddFlags(fs *flag.FlagSet) {
 	fs.StringVar(&(c.version), "v", "", "version")
+	fs.StringVar(&(c.source), "s", "", "source")
+	fs.BoolVar(&(c.override), "o", false, "override")
 	fs.BoolVar(&(c.palette), "p", false, "palette")
-
+	fs.BoolVar(&(c.updateIfExists), "u", false, "update if exists")
 }
 
 // Exec implementation of cli.Command.Exec
@@ -72,5 +77,10 @@ func (c *cmdInstall) Exec(args []string) error {
 		return InstallPalette(SetupExistingProjectEnv(appDir), contribPath)
 	}
 
-	return InstallDependency(SetupExistingProjectEnv(appDir), contribPath, version)
+	source := contribPath
+	if c.source != "" {
+		source = c.source
+	}
+
+	return InstallDependency(SetupExistingProjectEnv(appDir), contribPath, source, version, c.updateIfExists, c.override)
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[] Bugfix
[x] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: N/A

**What is the current behavior?**
When developing a contribution for Flogo, it is often mandatory to make updates in core repositories of Flogo (such as [TIBCOSoftware/flogo-contrib](https://github.com/TIBCOSoftware/flogo-contrib) and [TIBCOSoftware/flogo-lib](https://github.com/TIBCOSoftware/flogo-lib) repositories). Before a Pull Request can be created, these updates are commited and pushed to a forked repository on a new branch but must be imported in Go as if they were coming from official repositories. It is a tedious work to manage this workflow.

**What is the new behavior?**
The new behavior is to simplify the development of contributions in Flogo environment.
Especially, it adds following features :

* In ```flogo ensure``` command, a ```-dev``` switch enables the creation of symbolic links from vendor to pkg for explicit constraints in Gopkg.toml.

For instance, the following constraint:
```
[[constraint]]
  name = "github.com/TIBCOSoftware/flogo-contrib"
  branch = "some-branch"
  source = "github.com/alternate-account/flogo-contrib"
``` 
will remove the *$APP_HOME/src/APP_NAME/vendor/github.com/TIBCOSoftware/flogo-contrib* directory and replace it by a symbolic link to *$APP_HOME/pkg/dep/sources/https---github.com-alternate-account-flogo--contrib*.
Whereas the original *$APP_HOME/src/APP_NAME/vendor/github.com/TIBCOSoftware/flogo-contrib* directory which is just a copy of its counterpart in *$APP_HOME/pkg* with the right branch/version copied, the link points to a full Git working directory using the right branch/version too.
This is easier to manage updates to be commited and pushed to the fork in a single place.

* In ```flogo install```command, new flags are defined:
  * switch ```-s``` to specify an alternate source in a [[constraint]] of Gopkg.toml file
  * switch ```-u``` to force the update of a [[constraint]] in Gopkg.toml file if it already exists in Gopkg.lock file (currently it is ignored and a message asks to add it manually in the file)
  * switch ```-o``` to create an [[override]] instead of a [[constraint]] of Gopkg.toml file

For instance:
```
flogo install -u -v some-branch -s github.com/alternate-account/flogo-contrib github.com/TIBCOSoftware/flogo-contrib
flogo install -u -v some-branch -s github.com/alternate-account/flogo-lib github.com/TIBCOSoftware/flogo-lib
flogo install -u -o -v master github.com/apache/thrift
```

will create the following sections:

```
[[constraint]]
  name = "github.com/TIBCOSoftware/flogo-contrib"
  branch = "some-branch"
  source = "github.com/alternate-account/flogo-contrib"

[[constraint]]
  name = "github.com/TIBCOSoftware/flogo-lib"
  branch = "some-branch"
  source = "github.com/alternate-account/flogo-lib"

[[override]]
  name = "github.com/apache/thrift"
  branch = "master"
```

Once the alternate configuration is set in Gopkg.toml, a call to ```flogo ensure -dev``` will prepare the application for development mode.

**How to install to test?**
```
go get -u github.com/TIBCOSoftware/flogo-cli/...

cd $GOPATH/src/github.com/TIBCOSoftware/flogo-cli

git remote add square-it https://github.com/square-it/flogo-cli.git
git pull square-it ensure-development-mode

go get -u ./...
```

and to switch back to the official Flogo CLI, simply run:
```
rm -rf $GOPATH/src/github.com/TIBCOSoftware/flogo-cli

go get -u github.com/TIBCOSoftware/flogo-cli/...
```